### PR TITLE
Fix incorrect login credentials in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ frontend/dist/
 
 # MySQL data (if local)
 mysql_data/
+
+# Issues file
+issues.md

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ The dev data initializer creates the following accounts:
 | Role       | Email               | Password |
 |------------|---------------------|----------|
 | Admin      | b.wei@abc.edu       | 123456   |
-| Instructor | a.jones@abc.edu     | 123456   |
+| Instructor | s.johnson@abc.edu   | 123456   |
 | Student    | j.smith@abc.edu     | 123456   |
-| Student    | e.johnson@abc.edu   | 123456   |
-| Student    | m.williams@abc.edu  | 123456   |
-| Student    | s.brown@abc.edu     | 123456   |
-| Student    | d.davis@abc.edu     | 123456   |
-| Student    | l.wilson@abc.edu    | 123456   |
+| Student    | e.davis@abc.edu     | 123456   |
+| Student    | m.brown@abc.edu     | 123456   |
+| Student    | s.wilson@abc.edu    | 123456   |
+| Student    | d.taylor@abc.edu    | 123456   |
+| Student    | l.anderson@abc.edu  | 123456   |
 
 ---
 


### PR DESCRIPTION
## Summary

  - Updated the default login credentials table in README.md to match the actual seed data in DataInitializer.java
  - The previous emails (e.g. a.jones@abc.edu, e.johnson@abc.edu) did not exist in the database, causing 401 errors when teammates tried to log in

## Test plan

  - Start the app with docker compose up -d and mvn spring-boot:run
  - Verify each email in the README table can successfully log in with password 123456