### PR TITLE
  Fix peer evaluation submission crash and missing teammates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ A full-stack peer evaluation and project management platform built for academic 
 
 Make sure you have the following installed on your machine:
 
-| Tool       | Version   | Download                                      |
-|------------|-----------|-----------------------------------------------|
-| Java       | 21+       | https://adoptium.net/                         |
-| Node.js    | 18+       | https://nodejs.org/                           |
-| Docker     | 20+       | https://www.docker.com/products/docker-desktop|
-| Maven      | 3.9+      | Included via `./mvnw` wrapper in backend      |
+| Tool    | Version | Download                                       |
+| ------- | ------- | ---------------------------------------------- |
+| Java    | 21+     | https://adoptium.net/                          |
+| Node.js | 18+     | https://nodejs.org/                            |
+| Docker  | 20+     | https://www.docker.com/products/docker-desktop |
+| Maven   | 3.9+    | Included via `./mvnw` wrapper in backend       |
 
 ---
 
@@ -67,6 +67,7 @@ docker compose up -d
 ```
 
 This starts:
+
 - **MySQL 8** on port `3306` (database: `project-pulse`, user: `root`, password: `123456`)
 - **Mailpit** — SMTP on port `1025`, Web UI on port `8025`
 
@@ -109,16 +110,16 @@ The frontend starts on **http://localhost:5173**.
 
 The dev data initializer creates the following accounts:
 
-| Role       | Email               | Password |
-|------------|---------------------|----------|
-| Admin      | b.wei@abc.edu       | 123456   |
-| Instructor | s.johnson@abc.edu   | 123456   |
-| Student    | j.smith@abc.edu     | 123456   |
-| Student    | e.davis@abc.edu     | 123456   |
-| Student    | m.brown@abc.edu     | 123456   |
-| Student    | s.wilson@abc.edu    | 123456   |
-| Student    | d.taylor@abc.edu    | 123456   |
-| Student    | l.anderson@abc.edu  | 123456   |
+| Role       | Email              | Password   |
+| ---------- | ------------------ | ---------- |
+| Admin      | b.wei@abc.edu      | 123456     |
+| Instructor | s.johnson@abc.edu  | 123456     |
+| Student    | j.smith@abc.edu    | 123456     |
+| Student    | e.davis@abc.edu    | helloworld |
+| Student    | m.brown@abc.edu    | 123456     |
+| Student    | s.wilson@abc.edu   | 123456     |
+| Student    | d.taylor@abc.edu   | 123456     |
+| Student    | l.anderson@abc.edu | 123456     |
 
 ---
 
@@ -133,6 +134,7 @@ Open the Mailpit web UI at: **http://localhost:8025**
 ## Key Features
 
 ### Admin / Instructor
+
 - Create and manage **courses**, **sections**, and **teams**
 - Configure **rubrics** with custom evaluation criteria
 - **Invite students and instructors** via email
@@ -144,11 +146,13 @@ Open the Mailpit web UI at: **http://localhost:8025**
 - **Activate/deactivate** instructor accounts
 
 ### Student
+
 - Log **weekly activities** (category, description, planned/actual hours, status)
 - **Submit peer evaluations** for teammates using the section's rubric
 - View **personal evaluation report** with averaged scores and public comments
 
 ### Authentication
+
 - **Email invitation-based registration** with token validation
 - **JWT authentication** (2-hour token expiry)
 - **Password reset** via email link
@@ -170,6 +174,7 @@ All API endpoints are prefixed with `/api/v1`. The backend uses a standard respo
 ```
 
 Authentication:
+
 - **Login:** `POST /api/v1/users/login` (HTTP Basic Auth)
 - **All other endpoints:** Bearer JWT token in `Authorization` header
 
@@ -177,23 +182,23 @@ Authentication:
 
 ## Tech Stack
 
-| Layer    | Technology                                      |
-|----------|-------------------------------------------------|
+| Layer    | Technology                                                   |
+| -------- | ------------------------------------------------------------ |
 | Backend  | Spring Boot 3.4.1, Spring Security, Spring Data JPA, Java 21 |
-| Frontend | Vue 3, Vite 6, Element Plus, Pinia, Axios, Chart.js |
-| Database | MySQL 8                                         |
-| Email    | Spring Mail + Mailpit (dev)                     |
-| Auth     | JWT (RSA-signed) via Spring OAuth2 Resource Server |
+| Frontend | Vue 3, Vite 6, Element Plus, Pinia, Axios, Chart.js          |
+| Database | MySQL 8                                                      |
+| Email    | Spring Mail + Mailpit (dev)                                  |
+| Auth     | JWT (RSA-signed) via Spring OAuth2 Resource Server           |
 
 ---
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| `Port 80 already in use` | Stop any process on port 80, or change the port in `backend/src/main/resources/application.yml` |
-| `Port 3306 already in use` | Stop any local MySQL instance, or change the port in `docker-compose.yml` and `application-dev.yml` |
-| `npm install` fails with peer dependency errors | Use `npm install --legacy-peer-deps` |
-| Backend can't connect to MySQL | Make sure Docker containers are running: `docker compose ps` |
-| Login returns 401 | Double-check email and password; the dev seed data uses the credentials listed above |
-| Emails not showing up | Check Mailpit at http://localhost:8025 — emails are captured there, not sent externally |
+| Problem                                         | Solution                                                                                            |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Port 80 already in use`                        | Stop any process on port 80, or change the port in `backend/src/main/resources/application.yml`     |
+| `Port 3306 already in use`                      | Stop any local MySQL instance, or change the port in `docker-compose.yml` and `application-dev.yml` |
+| `npm install` fails with peer dependency errors | Use `npm install --legacy-peer-deps`                                                                |
+| Backend can't connect to MySQL                  | Make sure Docker containers are running: `docker compose ps`                                        |
+| Login returns 401                               | Double-check email and password; the dev seed data uses the credentials listed above                |
+| Emails not showing up                           | Check Mailpit at http://localhost:8025 — emails are captured there, not sent externally             |

--- a/backend/src/main/java/team/projectpulse/security/AuthController.java
+++ b/backend/src/main/java/team/projectpulse/security/AuthController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RestController;
 import team.projectpulse.system.Result;
 import team.projectpulse.system.StatusCode;
 
+import team.projectpulse.student.Student;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +36,11 @@ public class AuthController {
         userInfo.put("email", user.getEmail());
         userInfo.put("roles", user.getRoles());
         userInfo.put("enabled", user.isEnabled());
+
+        if (user instanceof Student student) {
+            userInfo.put("teamId", student.getTeam() != null ? student.getTeam().getId() : null);
+            userInfo.put("sectionId", student.getSection() != null ? student.getSection().getId() : null);
+        }
 
         Map<String, Object> loginResult = new HashMap<>();
         loginResult.put("userInfo", userInfo);

--- a/frontend/src/pages/student/SubmitEvaluation.vue
+++ b/frontend/src/pages/student/SubmitEvaluation.vue
@@ -54,8 +54,6 @@ async function loadData() {
     // Get teammates from same team
     const studentRes = await getStudents({ teamId: userInfoStore.userInfo.teamId || '' })
     const allStudents = studentRes.data || []
-    // Include self in evaluations
-    teammates.value = allStudents
 
     // Get rubric criteria from section
     const secRes = await getSections()
@@ -67,13 +65,14 @@ async function loadData() {
       if (rubric) criteria.value = rubric.criteria
     }
 
-    // Initialize eval data for each teammate
-    for (const mate of teammates.value) {
+    // Initialize eval data for each teammate before setting teammates to avoid render errors
+    for (const mate of allStudents) {
       evalData[mate.id] = { publicComment: '', privateComment: '', ratings: {} }
       for (const c of criteria.value) {
         evalData[mate.id].ratings[c.id] = 0
       }
     }
+    teammates.value = allStudents
   } catch {} finally { loading.value = false }
 }
 


### PR DESCRIPTION
 ## Summary
  - Include `teamId` and `sectionId` in the login response for student
  users in `AuthController.java`, so the frontend can filter teammates
  by team
  - Fix render crash (`Cannot read properties of undefined`) in
  `SubmitEvaluation.vue` by initializing `evalData` before setting
  `teammates.value`

  ## Files Changed
  -
  `backend/src/main/java/team/projectpulse/security/AuthController.java`
  - `frontend/src/pages/student/SubmitEvaluation.vue`

  ## Test plan
  - [x] Log in as a student (e.g. `j.smith@abc.edu`)
  - [x] Navigate to Submit Evaluation — all teammates should appear
  - [x] Submit evaluations — no console errors
  - [x] Log in as a different student on the same team — confirm their
  teammates also appear

  Closes #8