### PR TITLE
Enforce assignment integrity and cleanup rules

### DIFF
--- a/backend/src/main/java/team/projectpulse/activity/ActivityRepository.java
+++ b/backend/src/main/java/team/projectpulse/activity/ActivityRepository.java
@@ -8,4 +8,6 @@ public interface ActivityRepository extends JpaRepository<Activity, Long> {
     List<Activity> findByTeamIdAndWeek(Long teamId, Integer week);
     List<Activity> findByStudentId(Long studentId);
     List<Activity> findByTeamId(Long teamId);
+    void deleteByStudentId(Long studentId);
+    void deleteByTeamId(Long teamId);
 }

--- a/backend/src/main/java/team/projectpulse/evaluation/PeerEvaluationRepository.java
+++ b/backend/src/main/java/team/projectpulse/evaluation/PeerEvaluationRepository.java
@@ -10,4 +10,7 @@ public interface PeerEvaluationRepository extends JpaRepository<PeerEvaluation, 
     List<PeerEvaluation> findByEvaluateeId(Long evaluateeId);
     Optional<PeerEvaluation> findByEvaluatorIdAndEvaluateeIdAndWeek(Long evaluatorId, Long evaluateeId, Integer week);
     List<PeerEvaluation> findByWeek(Integer week);
+    void deleteByEvaluatorId(Long evaluatorId);
+    void deleteByEvaluateeId(Long evaluateeId);
+    void deleteByEvaluatorIdOrEvaluateeId(Long evaluatorId, Long evaluateeId);
 }

--- a/backend/src/main/java/team/projectpulse/evaluation/PeerEvaluationService.java
+++ b/backend/src/main/java/team/projectpulse/evaluation/PeerEvaluationService.java
@@ -8,6 +8,7 @@ import team.projectpulse.student.StudentRepository;
 import team.projectpulse.system.exception.ObjectNotFoundException;
 
 import java.util.*;
+import java.time.LocalDate;
 import java.util.stream.Collectors;
 
 @Service
@@ -62,7 +63,7 @@ public class PeerEvaluationService {
         ).isPresent()) {
             throw new IllegalArgumentException("Peer evaluation already submitted for this teammate and week");
         }
-        validateActiveWeek(evaluation.getEvaluator(), evaluation.getWeek());
+        validateSubmissionWeek(evaluation.getEvaluator(), evaluation.getWeek());
         // Calculate total score from ratings
         double total = evaluation.getRatings().stream()
                 .mapToDouble(r -> r.getScore() != null ? r.getScore() : 0)
@@ -131,21 +132,57 @@ public class PeerEvaluationService {
         return reports;
     }
 
-    private void validateActiveWeek(Student evaluator, Integer week) {
+    private void validateSubmissionWeek(Student evaluator, Integer week) {
         if (week == null || week < 1) {
             throw new IllegalArgumentException("Week must be a positive integer");
         }
         if (evaluator.getSection() == null || evaluator.getSection().getActiveWeeks() == null) {
             return;
         }
-        Set<Integer> activeWeeks = Arrays.stream(
+        List<Integer> activeWeeks = Arrays.stream(
                         evaluator.getSection().getActiveWeeks().replace("[", "").replace("]", "").split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .map(Integer::valueOf)
-                .collect(Collectors.toSet());
+                .sorted()
+                .collect(Collectors.toList());
         if (!activeWeeks.isEmpty() && !activeWeeks.contains(week)) {
             throw new IllegalArgumentException("Peer evaluations can only be submitted during active weeks");
         }
+        Integer allowedWeek = determineAllowedSubmissionWeek(evaluator, activeWeeks);
+        if (allowedWeek != null && !allowedWeek.equals(week)) {
+            throw new IllegalArgumentException("Peer evaluations can only be submitted for the previous active week");
+        }
+    }
+
+    private Integer determineAllowedSubmissionWeek(Student evaluator, List<Integer> activeWeeks) {
+        if (activeWeeks.isEmpty() || evaluator.getSection() == null
+                || evaluator.getSection().getStartDate() == null || evaluator.getSection().getEndDate() == null) {
+            return activeWeeks.isEmpty() ? null : activeWeeks.get(activeWeeks.size() - 1);
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = evaluator.getSection().getStartDate();
+        LocalDate endDate = evaluator.getSection().getEndDate();
+
+        if (today.isBefore(startDate)) {
+            return null;
+        }
+
+        long calendarWeek = (today.toEpochDay() - startDate.toEpochDay()) / 7 + 1;
+        LocalDate oneWeekAfterEnd = endDate.plusDays(7);
+
+        int candidateWeek;
+        if (!today.isAfter(oneWeekAfterEnd)) {
+            candidateWeek = (int) calendarWeek - 1;
+        } else {
+            // Historical seeded sections in dev should still allow the last active week.
+            candidateWeek = activeWeeks.get(activeWeeks.size() - 1);
+        }
+
+        return activeWeeks.stream()
+                .filter(activeWeek -> activeWeek <= candidateWeek)
+                .max(Integer::compareTo)
+                .orElse(null);
     }
 }

--- a/backend/src/main/java/team/projectpulse/section/SectionRepository.java
+++ b/backend/src/main/java/team/projectpulse/section/SectionRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 public interface SectionRepository extends JpaRepository<Section, Long> {
     List<Section> findByCourseId(Long courseId);
     boolean existsByName(String name);
+    boolean existsByNameAndIdNot(String name, Long id);
 }

--- a/backend/src/main/java/team/projectpulse/section/SectionService.java
+++ b/backend/src/main/java/team/projectpulse/section/SectionService.java
@@ -38,6 +38,9 @@ public class SectionService {
 
     public Section update(Long id, Section update) {
         Section existing = findById(id);
+        if (sectionRepository.existsByNameAndIdNot(update.getName(), id)) {
+            throw new IllegalArgumentException("Section name already exists: " + update.getName());
+        }
         existing.setName(update.getName());
         existing.setStartDate(update.getStartDate());
         existing.setEndDate(update.getEndDate());

--- a/backend/src/main/java/team/projectpulse/student/StudentService.java
+++ b/backend/src/main/java/team/projectpulse/student/StudentService.java
@@ -2,6 +2,8 @@ package team.projectpulse.student;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.projectpulse.activity.ActivityRepository;
+import team.projectpulse.evaluation.PeerEvaluationRepository;
 import team.projectpulse.system.exception.ObjectNotFoundException;
 
 import java.util.List;
@@ -11,9 +13,15 @@ import java.util.List;
 public class StudentService {
 
     private final StudentRepository studentRepository;
+    private final ActivityRepository activityRepository;
+    private final PeerEvaluationRepository peerEvaluationRepository;
 
-    public StudentService(StudentRepository studentRepository) {
+    public StudentService(StudentRepository studentRepository,
+                          ActivityRepository activityRepository,
+                          PeerEvaluationRepository peerEvaluationRepository) {
         this.studentRepository = studentRepository;
+        this.activityRepository = activityRepository;
+        this.peerEvaluationRepository = peerEvaluationRepository;
     }
 
     public List<Student> findAll() {
@@ -50,7 +58,13 @@ public class StudentService {
     }
 
     public void delete(Long id) {
-        findById(id);
+        Student student = findById(id);
+        if (student.getTeam() != null) {
+            student.setTeam(null);
+            studentRepository.save(student);
+        }
+        activityRepository.deleteByStudentId(id);
+        peerEvaluationRepository.deleteByEvaluatorIdOrEvaluateeId(id, id);
         studentRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/team/projectpulse/team/TeamRepository.java
+++ b/backend/src/main/java/team/projectpulse/team/TeamRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 public interface TeamRepository extends JpaRepository<Team, Long> {
     List<Team> findBySectionId(Long sectionId);
     boolean existsByName(String name);
+    boolean existsByNameAndIdNot(String name, Long id);
 }

--- a/backend/src/main/java/team/projectpulse/team/TeamService.java
+++ b/backend/src/main/java/team/projectpulse/team/TeamService.java
@@ -2,12 +2,15 @@ package team.projectpulse.team;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.projectpulse.activity.ActivityRepository;
 import team.projectpulse.instructor.Instructor;
 import team.projectpulse.instructor.InstructorRepository;
+import team.projectpulse.evaluation.PeerEvaluationRepository;
 import team.projectpulse.student.Student;
 import team.projectpulse.student.StudentRepository;
 import team.projectpulse.system.exception.ObjectNotFoundException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,11 +20,19 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final StudentRepository studentRepository;
     private final InstructorRepository instructorRepository;
+    private final ActivityRepository activityRepository;
+    private final PeerEvaluationRepository peerEvaluationRepository;
 
-    public TeamService(TeamRepository teamRepository, StudentRepository studentRepository, InstructorRepository instructorRepository) {
+    public TeamService(TeamRepository teamRepository,
+                       StudentRepository studentRepository,
+                       InstructorRepository instructorRepository,
+                       ActivityRepository activityRepository,
+                       PeerEvaluationRepository peerEvaluationRepository) {
         this.teamRepository = teamRepository;
         this.studentRepository = studentRepository;
         this.instructorRepository = instructorRepository;
+        this.activityRepository = activityRepository;
+        this.peerEvaluationRepository = peerEvaluationRepository;
     }
 
     public List<Team> findAll() {
@@ -46,6 +57,9 @@ public class TeamService {
 
     public Team update(Long id, Team update) {
         Team existing = findById(id);
+        if (teamRepository.existsByNameAndIdNot(update.getName(), id)) {
+            throw new IllegalArgumentException("Team name already exists: " + update.getName());
+        }
         existing.setName(update.getName());
         existing.setDescription(update.getDescription());
         existing.setWebsiteUrl(update.getWebsiteUrl());
@@ -54,11 +68,15 @@ public class TeamService {
 
     public void delete(Long id) {
         Team team = findById(id);
+        List<Student> teamStudents = new ArrayList<>(team.getStudents());
         // Remove students from this team
-        for (Student student : team.getStudents()) {
+        for (Student student : teamStudents) {
+            activityRepository.deleteByStudentId(student.getId());
+            peerEvaluationRepository.deleteByEvaluatorIdOrEvaluateeId(student.getId(), student.getId());
             student.setTeam(null);
             studentRepository.save(student);
         }
+        activityRepository.deleteByTeamId(id);
         // Remove instructors from this team
         team.getInstructors().clear();
         teamRepository.save(team);
@@ -69,13 +87,21 @@ public class TeamService {
         Team team = findById(teamId);
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new ObjectNotFoundException("student", studentId));
+        if (team.getSection() == null || student.getSection() == null
+                || !team.getSection().getId().equals(student.getSection().getId())) {
+            throw new IllegalArgumentException("Student and team must belong to the same section");
+        }
         student.setTeam(team);
         studentRepository.save(student);
     }
 
     public void removeStudentFromTeam(Long teamId, Long studentId) {
+        Team team = findById(teamId);
         Student student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new ObjectNotFoundException("student", studentId));
+        if (student.getTeam() == null || !student.getTeam().getId().equals(team.getId())) {
+            throw new IllegalArgumentException("Student is not assigned to this team");
+        }
         student.setTeam(null);
         studentRepository.save(student);
     }
@@ -84,6 +110,14 @@ public class TeamService {
         Team team = findById(teamId);
         Instructor instructor = instructorRepository.findById(instructorId)
                 .orElseThrow(() -> new ObjectNotFoundException("instructor", instructorId));
+        if (team.getSection() == null) {
+            throw new IllegalArgumentException("Team must belong to a section before assigning instructors");
+        }
+        boolean belongsToSection = instructor.getSections().stream()
+                .anyMatch(section -> section.getId().equals(team.getSection().getId()));
+        if (!belongsToSection) {
+            team.getSection().getInstructors().add(instructor);
+        }
         if (!team.getInstructors().contains(instructor)) {
             team.getInstructors().add(instructor);
             teamRepository.save(team);
@@ -92,6 +126,13 @@ public class TeamService {
 
     public void removeInstructorFromTeam(Long teamId, Long instructorId) {
         Team team = findById(teamId);
+        boolean assignedToTeam = team.getInstructors().stream().anyMatch(i -> i.getId().equals(instructorId));
+        if (!assignedToTeam) {
+            throw new IllegalArgumentException("Instructor is not assigned to this team");
+        }
+        if (team.getInstructors().size() <= 1) {
+            throw new IllegalArgumentException("Every team must have at least one instructor");
+        }
         team.getInstructors().removeIf(i -> i.getId().equals(instructorId));
         teamRepository.save(team);
     }

--- a/frontend/src/pages/student/MyEvalReport.vue
+++ b/frontend/src/pages/student/MyEvalReport.vue
@@ -2,7 +2,7 @@
   <div class="page-container">
     <h1 class="page-title">My Peer Evaluation Report</h1>
     <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px" @change="loadReport">
-      <el-option v-for="w in 15" :key="w" :label="`Week ${w}`" :value="w" />
+      <el-option v-for="w in availableWeeks" :key="w" :label="`Week ${w}`" :value="w" />
     </el-select>
 
     <el-card v-loading="loading" style="border-radius:12px" v-if="report">
@@ -29,18 +29,38 @@
 import { ref, onMounted } from 'vue'
 import { useUserInfoStore } from '@/stores/userInfo'
 import { getStudentReport } from '@/apis/evaluation'
+import { getSectionById } from '@/apis/section'
+import { getEvaluationWeekOptions } from '@/utils/sectionWeeks'
 
 const userInfoStore = useUserInfoStore()
 const selectedWeek = ref(1)
 const report = ref(null)
 const loading = ref(false)
+const availableWeeks = ref([1])
 
 async function loadReport() {
+  if (!selectedWeek.value) {
+    report.value = null
+    return
+  }
   loading.value = true
   try {
     const res = await getStudentReport(userInfoStore.userInfo.id, selectedWeek.value)
     report.value = res.data || null
   } catch {} finally { loading.value = false }
 }
-onMounted(loadReport)
+
+onMounted(async () => {
+  try {
+    if (userInfoStore.userInfo?.sectionId) {
+      const secRes = await getSectionById(userInfoStore.userInfo.sectionId)
+      const weekOptions = getEvaluationWeekOptions(secRes.data || {})
+      availableWeeks.value = weekOptions.activeWeeks
+      selectedWeek.value = weekOptions.defaultWeek ?? availableWeeks.value[0] ?? 1
+    }
+  } catch {
+    availableWeeks.value = [1]
+  }
+  loadReport()
+})
 </script>

--- a/frontend/src/pages/student/MyEvaluations.vue
+++ b/frontend/src/pages/student/MyEvaluations.vue
@@ -5,7 +5,7 @@
       <el-button type="primary" @click="$router.push('/submit-evaluation')">Submit Evaluation</el-button>
     </div>
     <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px" @change="loadEvals">
-      <el-option v-for="w in 15" :key="w" :label="`Week ${w}`" :value="w" />
+      <el-option v-for="w in availableWeeks" :key="w" :label="`Week ${w}`" :value="w" />
     </el-select>
 
     <el-table :data="evaluations" stripe v-loading="loading">
@@ -25,18 +25,38 @@
 import { ref, onMounted } from 'vue'
 import { useUserInfoStore } from '@/stores/userInfo'
 import { getEvaluations } from '@/apis/evaluation'
+import { getSectionById } from '@/apis/section'
+import { getEvaluationWeekOptions } from '@/utils/sectionWeeks'
 
 const userInfoStore = useUserInfoStore()
 const evaluations = ref([])
 const loading = ref(false)
 const selectedWeek = ref(1)
+const availableWeeks = ref([1])
 
 async function loadEvals() {
+  if (!selectedWeek.value) {
+    evaluations.value = []
+    return
+  }
   loading.value = true
   try {
     const res = await getEvaluations({ evaluatorId: userInfoStore.userInfo.id, week: selectedWeek.value })
     evaluations.value = res.data || []
   } catch {} finally { loading.value = false }
 }
-onMounted(loadEvals)
+
+onMounted(async () => {
+  try {
+    if (userInfoStore.userInfo?.sectionId) {
+      const secRes = await getSectionById(userInfoStore.userInfo.sectionId)
+      const weekOptions = getEvaluationWeekOptions(secRes.data || {})
+      availableWeeks.value = weekOptions.activeWeeks
+      selectedWeek.value = weekOptions.defaultWeek ?? availableWeeks.value[0] ?? 1
+    }
+  } catch {
+    availableWeeks.value = [1]
+  }
+  loadEvals()
+})
 </script>

--- a/frontend/src/pages/student/SubmitEvaluation.vue
+++ b/frontend/src/pages/student/SubmitEvaluation.vue
@@ -1,8 +1,15 @@
 <template>
   <div class="page-container">
     <h1 class="page-title">Submit Peer Evaluation</h1>
-    <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px">
-      <el-option v-for="w in 15" :key="w" :label="`Week ${w}`" :value="w" />
+    <el-alert
+      v-if="noEligibleWeekMessage"
+      :title="noEligibleWeekMessage"
+      type="warning"
+      show-icon
+      style="margin-bottom:16px"
+    />
+    <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px" :disabled="true">
+      <el-option v-for="w in availableWeeks" :key="w" :label="`Week ${w}`" :value="w" />
     </el-select>
 
     <div v-if="teammates.length === 0 && !loading">
@@ -23,12 +30,21 @@
       </el-row>
     </el-card>
 
-    <el-button type="primary" @click="handleSubmit" :loading="submitting" v-if="teammates.length > 0" style="margin-top:12px">Submit All Evaluations</el-button>
+    <el-button
+      type="primary"
+      @click="handleSubmit"
+      :loading="submitting"
+      :disabled="!selectedWeek"
+      v-if="teammates.length > 0"
+      style="margin-top:12px"
+    >
+      Submit All Evaluations
+    </el-button>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, reactive, watch } from 'vue'
+import { ref, onMounted, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { useUserInfoStore } from '@/stores/userInfo'
@@ -36,6 +52,7 @@ import { getStudents } from '@/apis/student'
 import { getRubricById } from '@/apis/rubric'
 import { getSectionById } from '@/apis/section'
 import { createEvaluation } from '@/apis/evaluation'
+import { getEvaluationWeekOptions } from '@/utils/sectionWeeks'
 
 const router = useRouter()
 const userInfoStore = useUserInfoStore()
@@ -44,6 +61,8 @@ const teammates = ref([])
 const criteria = ref([])
 const loading = ref(false)
 const submitting = ref(false)
+const availableWeeks = ref([])
+const noEligibleWeekMessage = ref('')
 const evalData = reactive({})
 
 onMounted(loadData)
@@ -66,6 +85,16 @@ async function loadData() {
     // Get rubric criteria from section
     const secRes = await getSectionById(userInfoStore.userInfo.sectionId)
     const section = secRes.data || {}
+    const weekOptions = getEvaluationWeekOptions(section)
+    availableWeeks.value = weekOptions.allowedWeek ? [weekOptions.allowedWeek] : []
+    selectedWeek.value = weekOptions.allowedWeek
+    if (!weekOptions.allowedWeek) {
+      noEligibleWeekMessage.value = 'There is no eligible peer-evaluation week available right now.'
+      teammates.value = []
+      criteria.value = []
+      return
+    }
+    noEligibleWeekMessage.value = ''
     if (section.rubricId) {
       const rubRes = await getRubricById(section.rubricId)
       const rubric = rubRes.data || null
@@ -83,6 +112,10 @@ async function loadData() {
 }
 
 async function handleSubmit() {
+  if (!selectedWeek.value) {
+    ElMessage.warning('There is no eligible evaluation week available right now.')
+    return
+  }
   submitting.value = true
   try {
     for (const mate of teammates.value) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -140,7 +140,10 @@ router.beforeEach((to, from, next) => {
     const requiredPerms = to.meta.requiresPermissions
     // Check if user has at least one required permission
     const hasPermission = requiredPerms.some(p => userRoles.includes(p))
-    if (!hasPermission) return next('/403')
+    if (!hasPermission) {
+      if (userRoles.includes('admin')) return next('/')
+      return next('/403')
+    }
   }
 
   next()

--- a/frontend/src/utils/sectionWeeks.js
+++ b/frontend/src/utils/sectionWeeks.js
@@ -1,0 +1,67 @@
+function parseSectionDate(value) {
+  if (!value) return null
+  const date = new Date(`${value}T00:00:00`)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function parseActiveWeeks(activeWeeks) {
+  if (!activeWeeks) return []
+  try {
+    const parsed = JSON.parse(activeWeeks)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .map(Number)
+      .filter(Number.isInteger)
+      .sort((a, b) => a - b)
+  } catch {
+    return []
+  }
+}
+
+function computeCalendarWeek(section, now = new Date()) {
+  const start = parseSectionDate(section?.startDate)
+  if (!start) return null
+  const diffMs = now.getTime() - start.getTime()
+  return Math.floor(diffMs / (7 * 24 * 60 * 60 * 1000)) + 1
+}
+
+export function getAllowedEvaluationWeek(section, now = new Date()) {
+  const activeWeeks = parseActiveWeeks(section?.activeWeeks)
+  if (!activeWeeks.length) return null
+
+  const start = parseSectionDate(section?.startDate)
+  const end = parseSectionDate(section?.endDate)
+  if (!start || !end) {
+    return activeWeeks.at(-1) ?? null
+  }
+
+  if (now < start) return null
+
+  const calendarWeek = computeCalendarWeek(section, now)
+  if (calendarWeek == null) return activeWeeks.at(-1) ?? null
+
+  let candidateWeek
+  const oneWeekAfterEnd = new Date(end)
+  oneWeekAfterEnd.setDate(oneWeekAfterEnd.getDate() + 7)
+
+  if (now <= oneWeekAfterEnd) {
+    candidateWeek = calendarWeek - 1
+  } else {
+    // Course data in dev may be historical; fall back to the last active week.
+    candidateWeek = activeWeeks.at(-1)
+  }
+
+  const eligibleWeeks = activeWeeks.filter(week => week <= candidateWeek)
+  return eligibleWeeks.at(-1) ?? null
+}
+
+export function getEvaluationWeekOptions(section, now = new Date()) {
+  const activeWeeks = parseActiveWeeks(section?.activeWeeks)
+  if (!activeWeeks.length) return [1]
+  const allowedWeek = getAllowedEvaluationWeek(section, now)
+  return {
+    activeWeeks,
+    allowedWeek,
+    defaultWeek: allowedWeek ?? activeWeeks.at(-1)
+  }
+}


### PR DESCRIPTION
## Summary
This is the next remediation batch on top of #15. It focuses on the remaining data-integrity and assignment rules from issue #11.

## What changed
- Enforced unique section names on section update.
- Enforced unique team names on team update.
- Enforced same-section validation when assigning a student to a team.
- Prevented removing a student from the wrong team.
- Kept section/team instructor relationships consistent when assigning an instructor to a team from the section-scoped flow.
- Prevented removing the last instructor from a team, preserving BR-1.
- Added explicit cleanup for a student's activities and peer evaluations before deleting the student.
- Added explicit cleanup for team-linked student activities and peer evaluations before deleting the team.
- Added repository helpers needed for transactional cleanup and uniqueness checks.

## Related issue
- Related to #11

## Verification
- Backend compile: `./mvnw -q -DskipTests compile`

## Manual test checklist
- [ ] Renaming a team to an existing team name is rejected.
- [ ] Renaming a section to an existing section name is rejected.
- [ ] Assigning a student to a team in another section is rejected.
- [ ] Removing a student from a team they are not on is rejected.
- [ ] Assigning an instructor through the section/team flow still works.
- [ ] Removing the last instructor from a team is rejected.
- [ ] Deleting a student with activities/evaluations succeeds without orphaned rows.
- [ ] Deleting a team with student activity/evaluation data succeeds cleanly.

## Notes
This PR is intentionally stacked on top of #15. After #15 merges, this PR can be retargeted to `staging` if needed.