### PR TITLE
Align peer evaluation week selection with section rules

### DIFF
--- a/backend/src/main/java/team/projectpulse/evaluation/PeerEvaluationService.java
+++ b/backend/src/main/java/team/projectpulse/evaluation/PeerEvaluationService.java
@@ -8,6 +8,7 @@ import team.projectpulse.student.StudentRepository;
 import team.projectpulse.system.exception.ObjectNotFoundException;
 
 import java.util.*;
+import java.time.LocalDate;
 import java.util.stream.Collectors;
 
 @Service
@@ -62,7 +63,7 @@ public class PeerEvaluationService {
         ).isPresent()) {
             throw new IllegalArgumentException("Peer evaluation already submitted for this teammate and week");
         }
-        validateActiveWeek(evaluation.getEvaluator(), evaluation.getWeek());
+        validateSubmissionWeek(evaluation.getEvaluator(), evaluation.getWeek());
         // Calculate total score from ratings
         double total = evaluation.getRatings().stream()
                 .mapToDouble(r -> r.getScore() != null ? r.getScore() : 0)
@@ -131,21 +132,57 @@ public class PeerEvaluationService {
         return reports;
     }
 
-    private void validateActiveWeek(Student evaluator, Integer week) {
+    private void validateSubmissionWeek(Student evaluator, Integer week) {
         if (week == null || week < 1) {
             throw new IllegalArgumentException("Week must be a positive integer");
         }
         if (evaluator.getSection() == null || evaluator.getSection().getActiveWeeks() == null) {
             return;
         }
-        Set<Integer> activeWeeks = Arrays.stream(
+        List<Integer> activeWeeks = Arrays.stream(
                         evaluator.getSection().getActiveWeeks().replace("[", "").replace("]", "").split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .map(Integer::valueOf)
-                .collect(Collectors.toSet());
+                .sorted()
+                .collect(Collectors.toList());
         if (!activeWeeks.isEmpty() && !activeWeeks.contains(week)) {
             throw new IllegalArgumentException("Peer evaluations can only be submitted during active weeks");
         }
+        Integer allowedWeek = determineAllowedSubmissionWeek(evaluator, activeWeeks);
+        if (allowedWeek != null && !allowedWeek.equals(week)) {
+            throw new IllegalArgumentException("Peer evaluations can only be submitted for the previous active week");
+        }
+    }
+
+    private Integer determineAllowedSubmissionWeek(Student evaluator, List<Integer> activeWeeks) {
+        if (activeWeeks.isEmpty() || evaluator.getSection() == null
+                || evaluator.getSection().getStartDate() == null || evaluator.getSection().getEndDate() == null) {
+            return activeWeeks.isEmpty() ? null : activeWeeks.get(activeWeeks.size() - 1);
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = evaluator.getSection().getStartDate();
+        LocalDate endDate = evaluator.getSection().getEndDate();
+
+        if (today.isBefore(startDate)) {
+            return null;
+        }
+
+        long calendarWeek = (today.toEpochDay() - startDate.toEpochDay()) / 7 + 1;
+        LocalDate oneWeekAfterEnd = endDate.plusDays(7);
+
+        int candidateWeek;
+        if (!today.isAfter(oneWeekAfterEnd)) {
+            candidateWeek = (int) calendarWeek - 1;
+        } else {
+            // Historical seeded sections in dev should still allow the last active week.
+            candidateWeek = activeWeeks.get(activeWeeks.size() - 1);
+        }
+
+        return activeWeeks.stream()
+                .filter(activeWeek -> activeWeek <= candidateWeek)
+                .max(Integer::compareTo)
+                .orElse(null);
     }
 }

--- a/frontend/src/pages/student/MyEvalReport.vue
+++ b/frontend/src/pages/student/MyEvalReport.vue
@@ -2,7 +2,7 @@
   <div class="page-container">
     <h1 class="page-title">My Peer Evaluation Report</h1>
     <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px" @change="loadReport">
-      <el-option v-for="w in 15" :key="w" :label="`Week ${w}`" :value="w" />
+      <el-option v-for="w in availableWeeks" :key="w" :label="`Week ${w}`" :value="w" />
     </el-select>
 
     <el-card v-loading="loading" style="border-radius:12px" v-if="report">
@@ -29,18 +29,38 @@
 import { ref, onMounted } from 'vue'
 import { useUserInfoStore } from '@/stores/userInfo'
 import { getStudentReport } from '@/apis/evaluation'
+import { getSectionById } from '@/apis/section'
+import { getEvaluationWeekOptions } from '@/utils/sectionWeeks'
 
 const userInfoStore = useUserInfoStore()
 const selectedWeek = ref(1)
 const report = ref(null)
 const loading = ref(false)
+const availableWeeks = ref([1])
 
 async function loadReport() {
+  if (!selectedWeek.value) {
+    report.value = null
+    return
+  }
   loading.value = true
   try {
     const res = await getStudentReport(userInfoStore.userInfo.id, selectedWeek.value)
     report.value = res.data || null
   } catch {} finally { loading.value = false }
 }
-onMounted(loadReport)
+
+onMounted(async () => {
+  try {
+    if (userInfoStore.userInfo?.sectionId) {
+      const secRes = await getSectionById(userInfoStore.userInfo.sectionId)
+      const weekOptions = getEvaluationWeekOptions(secRes.data || {})
+      availableWeeks.value = weekOptions.activeWeeks
+      selectedWeek.value = weekOptions.defaultWeek ?? availableWeeks.value[0] ?? 1
+    }
+  } catch {
+    availableWeeks.value = [1]
+  }
+  loadReport()
+})
 </script>

--- a/frontend/src/pages/student/MyEvaluations.vue
+++ b/frontend/src/pages/student/MyEvaluations.vue
@@ -5,7 +5,7 @@
       <el-button type="primary" @click="$router.push('/submit-evaluation')">Submit Evaluation</el-button>
     </div>
     <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px" @change="loadEvals">
-      <el-option v-for="w in 15" :key="w" :label="`Week ${w}`" :value="w" />
+      <el-option v-for="w in availableWeeks" :key="w" :label="`Week ${w}`" :value="w" />
     </el-select>
 
     <el-table :data="evaluations" stripe v-loading="loading">
@@ -25,18 +25,38 @@
 import { ref, onMounted } from 'vue'
 import { useUserInfoStore } from '@/stores/userInfo'
 import { getEvaluations } from '@/apis/evaluation'
+import { getSectionById } from '@/apis/section'
+import { getEvaluationWeekOptions } from '@/utils/sectionWeeks'
 
 const userInfoStore = useUserInfoStore()
 const evaluations = ref([])
 const loading = ref(false)
 const selectedWeek = ref(1)
+const availableWeeks = ref([1])
 
 async function loadEvals() {
+  if (!selectedWeek.value) {
+    evaluations.value = []
+    return
+  }
   loading.value = true
   try {
     const res = await getEvaluations({ evaluatorId: userInfoStore.userInfo.id, week: selectedWeek.value })
     evaluations.value = res.data || []
   } catch {} finally { loading.value = false }
 }
-onMounted(loadEvals)
+
+onMounted(async () => {
+  try {
+    if (userInfoStore.userInfo?.sectionId) {
+      const secRes = await getSectionById(userInfoStore.userInfo.sectionId)
+      const weekOptions = getEvaluationWeekOptions(secRes.data || {})
+      availableWeeks.value = weekOptions.activeWeeks
+      selectedWeek.value = weekOptions.defaultWeek ?? availableWeeks.value[0] ?? 1
+    }
+  } catch {
+    availableWeeks.value = [1]
+  }
+  loadEvals()
+})
 </script>

--- a/frontend/src/pages/student/SubmitEvaluation.vue
+++ b/frontend/src/pages/student/SubmitEvaluation.vue
@@ -1,8 +1,15 @@
 <template>
   <div class="page-container">
     <h1 class="page-title">Submit Peer Evaluation</h1>
-    <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px">
-      <el-option v-for="w in 15" :key="w" :label="`Week ${w}`" :value="w" />
+    <el-alert
+      v-if="noEligibleWeekMessage"
+      :title="noEligibleWeekMessage"
+      type="warning"
+      show-icon
+      style="margin-bottom:16px"
+    />
+    <el-select v-model="selectedWeek" placeholder="Select Week" style="margin-bottom:16px;width:200px" :disabled="true">
+      <el-option v-for="w in availableWeeks" :key="w" :label="`Week ${w}`" :value="w" />
     </el-select>
 
     <div v-if="teammates.length === 0 && !loading">
@@ -23,12 +30,21 @@
       </el-row>
     </el-card>
 
-    <el-button type="primary" @click="handleSubmit" :loading="submitting" v-if="teammates.length > 0" style="margin-top:12px">Submit All Evaluations</el-button>
+    <el-button
+      type="primary"
+      @click="handleSubmit"
+      :loading="submitting"
+      :disabled="!selectedWeek"
+      v-if="teammates.length > 0"
+      style="margin-top:12px"
+    >
+      Submit All Evaluations
+    </el-button>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, reactive, watch } from 'vue'
+import { ref, onMounted, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage } from 'element-plus'
 import { useUserInfoStore } from '@/stores/userInfo'
@@ -36,6 +52,7 @@ import { getStudents } from '@/apis/student'
 import { getRubricById } from '@/apis/rubric'
 import { getSectionById } from '@/apis/section'
 import { createEvaluation } from '@/apis/evaluation'
+import { getEvaluationWeekOptions } from '@/utils/sectionWeeks'
 
 const router = useRouter()
 const userInfoStore = useUserInfoStore()
@@ -44,6 +61,8 @@ const teammates = ref([])
 const criteria = ref([])
 const loading = ref(false)
 const submitting = ref(false)
+const availableWeeks = ref([])
+const noEligibleWeekMessage = ref('')
 const evalData = reactive({})
 
 onMounted(loadData)
@@ -66,6 +85,16 @@ async function loadData() {
     // Get rubric criteria from section
     const secRes = await getSectionById(userInfoStore.userInfo.sectionId)
     const section = secRes.data || {}
+    const weekOptions = getEvaluationWeekOptions(section)
+    availableWeeks.value = weekOptions.allowedWeek ? [weekOptions.allowedWeek] : []
+    selectedWeek.value = weekOptions.allowedWeek
+    if (!weekOptions.allowedWeek) {
+      noEligibleWeekMessage.value = 'There is no eligible peer-evaluation week available right now.'
+      teammates.value = []
+      criteria.value = []
+      return
+    }
+    noEligibleWeekMessage.value = ''
     if (section.rubricId) {
       const rubRes = await getRubricById(section.rubricId)
       const rubric = rubRes.data || null
@@ -83,6 +112,10 @@ async function loadData() {
 }
 
 async function handleSubmit() {
+  if (!selectedWeek.value) {
+    ElMessage.warning('There is no eligible evaluation week available right now.')
+    return
+  }
   submitting.value = true
   try {
     for (const mate of teammates.value) {

--- a/frontend/src/utils/sectionWeeks.js
+++ b/frontend/src/utils/sectionWeeks.js
@@ -1,0 +1,67 @@
+function parseSectionDate(value) {
+  if (!value) return null
+  const date = new Date(`${value}T00:00:00`)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function parseActiveWeeks(activeWeeks) {
+  if (!activeWeeks) return []
+  try {
+    const parsed = JSON.parse(activeWeeks)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .map(Number)
+      .filter(Number.isInteger)
+      .sort((a, b) => a - b)
+  } catch {
+    return []
+  }
+}
+
+function computeCalendarWeek(section, now = new Date()) {
+  const start = parseSectionDate(section?.startDate)
+  if (!start) return null
+  const diffMs = now.getTime() - start.getTime()
+  return Math.floor(diffMs / (7 * 24 * 60 * 60 * 1000)) + 1
+}
+
+export function getAllowedEvaluationWeek(section, now = new Date()) {
+  const activeWeeks = parseActiveWeeks(section?.activeWeeks)
+  if (!activeWeeks.length) return null
+
+  const start = parseSectionDate(section?.startDate)
+  const end = parseSectionDate(section?.endDate)
+  if (!start || !end) {
+    return activeWeeks.at(-1) ?? null
+  }
+
+  if (now < start) return null
+
+  const calendarWeek = computeCalendarWeek(section, now)
+  if (calendarWeek == null) return activeWeeks.at(-1) ?? null
+
+  let candidateWeek
+  const oneWeekAfterEnd = new Date(end)
+  oneWeekAfterEnd.setDate(oneWeekAfterEnd.getDate() + 7)
+
+  if (now <= oneWeekAfterEnd) {
+    candidateWeek = calendarWeek - 1
+  } else {
+    // Course data in dev may be historical; fall back to the last active week.
+    candidateWeek = activeWeeks.at(-1)
+  }
+
+  const eligibleWeeks = activeWeeks.filter(week => week <= candidateWeek)
+  return eligibleWeeks.at(-1) ?? null
+}
+
+export function getEvaluationWeekOptions(section, now = new Date()) {
+  const activeWeeks = parseActiveWeeks(section?.activeWeeks)
+  if (!activeWeeks.length) return [1]
+  const allowedWeek = getAllowedEvaluationWeek(section, now)
+  return {
+    activeWeeks,
+    allowedWeek,
+    defaultWeek: allowedWeek ?? activeWeeks.at(-1)
+  }
+}


### PR DESCRIPTION
## Summary
This is the next remediation batch on top of #16. It focuses on the remaining peer-evaluation week-selection and previous-week behavior from issue #12.

## What changed
- Added a frontend utility for parsing section active weeks and deriving evaluation-week options.
- Updated the student submit-evaluation page to stop offering a hardcoded `1..15` selector.
- Restricted the submit-evaluation flow to the currently eligible peer-evaluation week derived from section data.
- Added a warning state when no eligible evaluation week is available.
- Updated the student "My Peer Evaluations" page to derive week options from section active weeks.
- Updated the student "My Peer Evaluation Report" page to derive week options from section active weeks.
- Tightened backend validation so peer evaluations must target the allowed previous active week, not just any active week.
- Added a pragmatic fallback for historical seeded sections so local dev data remains usable after the course date range has passed.

## Related issue
- Related to #12

## Verification
- Backend compile: `./mvnw -q -DskipTests compile`
- Frontend build: `npm run build`

## Manual test checklist
- [ ] Student submit-evaluation no longer shows a generic `1..15` week selector.
- [ ] The submit-evaluation screen only allows the currently eligible week.
- [ ] Submitting for any non-eligible week is rejected by the backend.
- [ ] "My Peer Evaluations" uses section-driven week options.
- [ ] "My Peer Evaluation Report" uses section-driven week options.
- [ ] Historical seeded data still allows a sensible default week in local dev.

## Notes
This PR is intentionally stacked on top of #16. After #16 merges, this PR can be retargeted to `staging` if needed.